### PR TITLE
Lko

### DIFF
--- a/Main/LiDAR/lidar_module.cpp
+++ b/Main/LiDAR/lidar_module.cpp
@@ -12,7 +12,7 @@ void lidar_thread(
     while (running.load()) {
         if(run_lidar.load()) {
             lidar.scan_oneCycle();
-            auto scans = lidar.get_scanData();
+            auto scans = lidar.get_nearPoint();
             Logger::instance().info("lidar", "[LiDAR] Scannaing oneCycle");
             lidar_q.Produce(std::move(scans));
         }

--- a/Main/main.cpp
+++ b/Main/main.cpp
@@ -17,7 +17,7 @@
 #include "IMU/imu_module.h"
 #include "LiDAR/lidar_module.h"
 #include "LiDAR/Lidar.h"
-#include "Motor/motor_module.h"
+//#include "Motor/motor_module.h"
 #include "logger.h"
 
 using util::Logger;


### PR DESCRIPTION
라이다에서 맞지 않았던 데이터 타입 수정 (get_scanData >> get_nearPoint)
모터 모듈 빌드 안되고 있으므로 메인 브랜치에서는 주석처리함